### PR TITLE
Fix colab button

### DIFF
--- a/langkit/examples/LLM_to_WhyLabs.ipynb
+++ b/langkit/examples/LLM_to_WhyLabs.ipynb
@@ -17,10 +17,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/whylabs/whylogs/blob/mainline/python/examples/integrations/writers/Writing_to_WhyLabs.ipynb)"
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/whylabs/LanguageToolkit/blob/main/langkit/examples/LLM_to_WhyLabs.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
The colab button in the LLM_to_WhyLabs example pointed to the wrong repo, fixed!

example notebook change only.